### PR TITLE
Improve display of notice vs. message content in chatroom

### DIFF
--- a/models/chat.js
+++ b/models/chat.js
@@ -13,7 +13,11 @@ exports.build = function(mongoose, config) {
 		posted: {
 			type: Date,
 			default: Date.now
-		}
+		},
+    msg_type: {
+      type: String,
+      default: 'message'
+    }
 	});
 
 	return mongoose.model(name, schema);

--- a/public/css/cw-theme.css
+++ b/public/css/cw-theme.css
@@ -271,7 +271,9 @@ a {
 }
 .chatroom .chat-item {
 	display: block;
-	margin-bottom:10px;
+	margin-bottom: 8px;
+  font-size:15px;
+  color:rgb(101,115,126);
 }
 .chatroom p {
 	line-height:1.2em;
@@ -280,11 +282,9 @@ a {
 }
 .chatroom .chat-item > .username {
 	font-weight: bold;
-	display: inline-block;
 	font-size:16px;
 	color:rgb(192,197,206);
-	width: 120px;
-	padding-right: 15px;
+	padding-right: 4px;
 
 	/*transition:color .1s ease-in;*/
 }
@@ -292,21 +292,29 @@ a {
 	cursor: pointer;
 	color:#ffcc00;
 }
-.chatroom .chat-item > div {
-	display: inline-block;
-	font-size:15px;
-	vertical-align: top;
-	color:rgb(101,115,126);
+
+.chatroom .chat-item--message > .username::after {
+  content: ":";
 }
+
 .chatroom .chat-item > .message {
 	color: #93979E;
-	width: calc(100% - 120px);
 }
 .chatroom .chat-item > .message > .timestamp {
-	display: none;
+  display: none;
 	color: #54463e;
 	float: right;
 }
+
+.chatroom .chat-item--notice {
+  font-style: italic;
+}
+
+.chatroom .chat-item--notice > .username,
+.chatroom .chat-item--notice > .message{
+  color: #666;
+}
+
 .participants {
 	font-family: 'Brandon', Helvetica, Arial, sans-serif;
 	position: absolute;

--- a/public/js/cwfm.chatter.js
+++ b/public/js/cwfm.chatter.js
@@ -28,7 +28,8 @@ cwfm.chatter.ctrl  =  function( $scope, $http, $socket, $room ) {
 			author: data,
 			content: 'joined the room.',
 			room: $scope.room,
-			posted: Date.now()
+			posted: Date.now(),
+      msg_type: 'notice'
 		});
 	});
 
@@ -37,7 +38,8 @@ cwfm.chatter.ctrl  =  function( $scope, $http, $socket, $room ) {
 			author: data,
 			content: 'left the room.',
 			room: $scope.room,
-			posted: Date.now()
+			posted: Date.now(),
+      msg_type: 'notice'
 		});
 	});
 
@@ -48,7 +50,8 @@ cwfm.chatter.ctrl  =  function( $scope, $http, $socket, $room ) {
 				author: data.songDj,
 				content: 'started playing ' + data.song.name,
 				room: $scope.room,
-				posted: data.songStarted
+				posted: data.songStarted,
+        msg_type: 'notice'
 			});
 		};
 		if (delay > 0) {

--- a/views/includes/room/chatter.jade
+++ b/views/includes/room/chatter.jade
@@ -2,9 +2,9 @@
 		div(ng-show="room.abbr")
 			#chat-list.upper-chin.chatroom.overflow
 				ul
-					li.chat-item(ng-repeat="m in chat | filter:content")
-						div.username {{m.author.username}}:
-						div.message {{m.content}}
+					li.chat-item(class="chat-item--{{chat[$index].msg_type}}" ng-repeat="m in chat | filter:content")
+						span.username {{m.author.username}}
+						span.message {{m.content}}
 							em.timestamp {{m.posted}}
 
 			#listeners.col-md-2


### PR DESCRIPTION
Improves the chatroom theme so that "status" messages are differentiated from content making it easier to scan and ignore 'notices'.

![image](https://cloud.githubusercontent.com/assets/17613/3633022/0a592af4-0ed4-11e4-8baa-089d91db426f.png)
