### PR TITLE
Add support for launching application with `grunt server`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,46 @@
+/*!
+ * @file
+ * Grunt config file for CWFM.
+ */
+
+module.exports = function(grunt) {
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    shell: {
+      // Start mongodb, this should generally be run before attempting to launch
+      // the app.
+      mongodb: {
+        command: 'mongod --dbpath ./data/db',
+        options: {
+          async: true,
+          stdout: false,
+          stderr: true,
+          failOnError: true,
+          execOptions: {
+            cwd: '.'
+          }
+        }
+      }
+    },
+    nodemon: {
+      // Launch the express application.
+      dev: {
+        script: 'app.js',
+        watch: ['lib', 'models', 'routes']
+      }
+    }
+  });
+
+  grunt.loadNpmTasks('grunt-shell-spawn');
+  grunt.loadNpmTasks('grunt-nodemon');
+
+  // Helper to display information about how to connect to the app in your
+  // browser.
+  grunt.registerTask('announce', 'Print server info.', function() {
+    grunt.log.writeln('Starting CWFM on http://localhost:1501');
+  });
+
+  // Get the app up and running so you can connect and start listening to some
+  // sweet tunes.
+  grunt.registerTask('server', ['shell', 'announce', 'nodemon']);
+};

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ A social music player that uses node.js to manage music rooms.
 1. Configure your `config.js` file.
 
 ## Running
+If you use Grunt:
+
+1. `grunt server`
+
+Otherwise:
+
 1. `mongod --dbpath=./data/db`
 2. `node app.js`
 

--- a/package.json
+++ b/package.json
@@ -1,25 +1,26 @@
 {
-	"name": "cwfm",
-	"description": "Clockwork.FM",
-	"version": "0.0.2",
-	"private": true,
-	"scripts": {
-		"start": "node app.js"
-	},
-
-	"dependencies": {
-		"express": "4.0.0",
-		"jade": "1.3.1",
-
-		"static-favicon": "1.0.x",
-		"body-parser": "1.0.x",
-		"cookies": "0.4.x",
-		"method-override": "1.0.x",
-		"morgan": "1.0.x",
-
-		"socket.io": "1.0.x",
-
-		"mongoose": "3.8.x",
-		"sha1": "1.1.x"
-	}
+  "name": "cwfm",
+  "description": "Clockwork.FM",
+  "version": "0.0.2",
+  "private": true,
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "4.0.0",
+    "jade": "1.3.1",
+    "static-favicon": "1.0.x",
+    "body-parser": "1.0.x",
+    "cookies": "0.4.x",
+    "method-override": "1.0.x",
+    "morgan": "1.0.x",
+    "socket.io": "1.0.x",
+    "mongoose": "3.8.x",
+    "sha1": "1.1.x"
+  },
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-nodemon": "^0.3.0",
+    "grunt-shell-spawn": "^0.3.0"
+  }
 }


### PR DESCRIPTION
- Adds grunt and required plugins to package.json.
- Adds a Gruntfile.js with a "server" task to launch mongod and the
  node app.js file.
- Use nodemon to monitor changes to app.js, and any files in
  /lib, /modules, /routes, and automatically restart the server if
  any of them change.

This simplifies launching the app to just `grunt server`, and automatically restarts the server anytime the server code changes.
