### PR TITLE
Improve initial login process / display.

### DIFF
--- a/public/css/cw-theme.css
+++ b/public/css/cw-theme.css
@@ -19,6 +19,15 @@ body {
 html, body {
 	height:100%;
 }
+
+a {
+  text-decoration: underline;
+}
+
+a:hover {
+  cursor: pointer;
+}
+
 ul {
 	list-style: none;
 	margin: 0;
@@ -42,15 +51,172 @@ ul {
 a {
 	color: #ffcd05;
 }
-#cwfmUserCtrl {
-	display: none;
-	overflow-y: scroll;
-	position: absolute;
-	height: 100%;
-	width: 100%;
-	z-index: 999;
-	background: rgba(43, 43, 43, 0.90);
+
+header {
+  padding: 5px 20px;
 }
+
+.header__dropdown_menu {
+  background: #333;
+  padding: 20px;
+  position: absolute;
+  z-index: 999;
+}
+
+.header__dropdown_menu li {
+  margin: 10px 0;
+}
+
+#cwfmUserCtrl {
+	display: block;
+}
+
+.modal {
+  display: block;
+  background: #f3cc2e;
+  border: 5px solid #fff;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  webkit-border-radius: 8px;
+  -webkit-box-shadow: 0px -1px 20px #f3cc2e;
+  -moz-box-shadow: 0px -1px 20px #f3cc2e;
+  box-shadow: 0px -1px 20px #f3cc2e;
+  left: 12.5%;
+  max-height: 85%;
+  overflow-y: scroll;
+  padding: 20px;
+  position: absolute;
+  top: 40px;
+  width: 75%;
+  z-index: 999;
+}
+
+button.close {
+  background: #000;
+  border: 4px solid #fff;
+  border-radius: 22.5px;
+  color: #fff;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 20px;
+  right: 11.5%;
+  height: 45px;
+  width: 45px;
+  z-index: 1000;
+}
+
+.modal .modal-header,
+.modal .modal-content {
+  float: left;
+  clear: both;
+  width: 100%;
+}
+
+.cwfmUserCtrl-hidden {
+  display: none;
+}
+
+.cwfmUserCtrl-visible {
+  display: block;
+}
+
+.modal .column {
+  float: left;
+  padding: 20px;
+  width: 45%;
+}
+
+.modal .column:first-of-type {
+  border-right: 5px solid #fff;
+  height: 100%;
+  margin-bottom: -500px;
+  margin-right: 5%;
+  padding-bottom: 480px;
+  padding-right: 5%;
+}
+
+.modal a {
+  color: #000;
+}
+
+.modal h3 {
+  color: #000;
+  font-size: 2em;
+  margin: 0 0 .25em 0;
+}
+
+.modal label {
+  color: #000;
+}
+
+.modal input {
+  border: 1px solid #fff;
+  font-size: 1em;
+  outline: none;
+  padding: 8px 12px;;
+
+  -webkit-transition: all 0.30s ease-in-out;
+  -moz-transition: all 0.30s ease-in-out;
+  -ms-transition: all 0.30s ease-in-out;
+  -o-transition: all 0.30s ease-in-out;
+  transition: all 0.30s ease-in-out;
+
+  -webkit-box-shadow:inset 0 0 2px #999;
+  -moz-box-shadow:inset 0 0 2px #999;
+  box-shadow:inset 0 0 2px #999;
+}
+
+.modal input:focus {
+  border: 1px solid rgba(0, 0, 0, 1);
+}
+
+.modal button {
+  background: #000;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 1.2em;
+  margin: 8px;
+  padding: 8px 12px;
+}
+
+.modal button span {
+  margin-left: 12px;
+}
+
+#user-login input,
+#user-login button {
+  margin: 8px 0;
+  width: 100%;
+}
+
+.modal button:hover {
+  color: #f3cc2e;
+  cursor: pointer;
+}
+
+.avatar img {
+  min-width: 75px;
+  width: 10%;
+}
+
+#avatar-list {
+  float: left;
+  width: 100%;
+}
+
+#avatar-list div {
+  float: left;
+  min-width: 40px;
+  width: 5%;
+}
+
+#avatar-list div img {
+  min-width: 35px;
+  width: 100%;
+}
+
 .right-col {
 	right:0;
 	position: fixed;

--- a/public/js/cwfm.ui.js
+++ b/public/js/cwfm.ui.js
@@ -23,11 +23,4 @@ $( document ).ready(function() {
 		$playlists_btn.addClass('active');
 		$queue_btn.removeClass('active');
 	}
-
-	$('#admin_btn').on( 'click', function() {
-		$('#cwfmUserCtrl').show();
-	});
-	$('button.close').on('click', function() {
-		$('#cwfmUserCtrl').hide();
-	});
 });

--- a/views/home.jade
+++ b/views/home.jade
@@ -8,7 +8,6 @@ block scripts
 	script(src="/public/js/cwfm.home.app.js")
 
 block main
-	a#admin_btn(href="#admin_btn") Log In
 	div#cwfmUserCtrl(ng-controller="cwfmUserCtrl")
 		h2(ng-show="user.auth") Welcome back {{user.username}}!
 		include includes/user
@@ -23,7 +22,7 @@ block main
 					input.form-control(ng-model="new_room.abbr", placeholder="Abbreviation")
 				div.form-group
 					textarea.form-control(ng-model="new_room.description", placeholder="Description")
-				button.btn.btn-default(ng-click="make_room()") Create a room 
+				button.btn.btn-default(ng-click="make_room()") Create a room
 					span.glyphicon.glyphicon-plus-sign
 
 			h2 Join a room

--- a/views/includes/room/control.jade
+++ b/views/includes/room/control.jade
@@ -9,9 +9,6 @@ div(ng-show="room.abbr", data-step="1", data-intro="Here's where we keep the DJs
 	div(ng-show="djing()")
 		a(ng-click="undj()", href="#undj") Stop DJing
 
-	div
-		a#admin_btn(href="#admin_btn") Admin
-
 	ul
 		li.dj-item(ng-repeat="dj in room.djs")
 			img.avatar(ng-src="/avatar/{{dj.avatar}}")

--- a/views/includes/user.jade
+++ b/views/includes/user.jade
@@ -1,21 +1,23 @@
-#user-control.pull-right(ng-show="me.auth")
+#user-control(ng-show="me.auth")
 	h3(ng-if="error") {{error}}
 
-	.dropdown
-		img(ng-src="/avatar/{{me.avatar}}", height="30px")
-		a.dropdown-toggle.btn.btn-link.btn-lg(data-toggle="dropdown", href="#user") {{me.username}} 
+	.header__dropdown
+		a.header__dropdown_toggle(ng-model="toggle_dropdown", ng-click="toggle_dropdown=!toggle_dropdown")
+			img(ng-src="/avatar/{{me.avatar}}", height="30px")
+			{{me.username}}
 
-		ul.dropdown-menu
+
+		ul.header__dropdown_menu(ng-show="toggle_dropdown")
 			li
-				a(data-toggle="modal", data-target="#user-edit", href="#edit-user") 
+				a(ng-model="show_user_modal", ng-click="show_user_modal=!show_user_modal")
 					span.glyphicon.glyphicon-edit &nbsp;
 					span Edit profile
 			li(ng-show="me.admin")
-				a(data-toggle="modal", data-target="#admin-panel", href="#admin")
+				a(ng-model="show_user_modal", ng-click="show_user_modal=!show_user_modal")
 					span.glyphicon.glyphicon-cog &nbsp;
 					span Administration
 			li
-				a(onclick="javascript:introJs().start(); return false;", href="#tour") 
+				a(onclick="javascript:introJs().start(); return false;", href="#tour")
 					span.glyphicon.glyphicon-road &nbsp;
 					span Tour Guide
 			li
@@ -23,52 +25,43 @@
 					span.glyphicon.glyphicon-log-out &nbsp;
 					span Log Out
 
-	.modal#user-edit
+	button.close(ng-model="show_user_modal", ng-click="show_user_modal=!show_user_modal" ng-show="!me.auth || show_user_modal") &times;
+	.modal#user-edit(ng-show="!me.auth || show_user_modal")
 		.modal-dialog.modal-lg
 			.modal-content
-				.modal-header
-					button.close(data-dismiss="modal") &times;
-					h3 Update your Profile 
 				.modal-body
+					h3 Update your Profile
 					form
 						.row
+							.avatar
+								strong(ng-show="avatarUrls") Select a New Avatar
+								.form-group.center-block
+									a(ng-click="loadAvatars()", href="#select-avatar")
+										img(ng-src="/avatar/{{me.avatar}}")
+								.row#avatar-list(ng-show="avatarUrls")
+									.col-md-3(ng-repeat="url in avatarUrls")
+										a.thumbnail(ng-click="selectAvatar(url)", href="#select-avatar")
+											img(ng-src="/avatar/{{url}}")
 							.col-md-4
 								.form-group
 									label(for="realname") Real name
 									input#realname(ng-model="me.realname", placeholder="Your real name")
 
-								.form-group.center-block
-									a(ng-click="loadAvatars()", href="#select-avatar")
-										img(ng-src="/avatar/{{me.avatar}}")
-
-							.col-md-8
-								strong(ng-show="avatarUrls") Select a New Avatar
-								.row#avatar-list(ng-show="avatarUrls")
-									.col-md-3(ng-repeat="url in avatarUrls")
-										a.thumbnail(ng-click="selectAvatar(url)", href="#select-avatar")
-											img(ng-src="/avatar/{{url}}")
 					.clearfix
-				.modal-footer
 					button.btn.btn-default(data-dismiss="modal") Cancel
 					button.btn.btn-primary(data-dismiss="modal", ng-click="save()") Save Changes
 
-	.modal#admin-panel
-		.modal-dialog
-			.modal-content
-				.modal-header
-					button.close(data-dismiss="modal") &times;
 					h3 Administration
-					.alert.alert-info.alert-dismissable(ng-show="adminMessage", ng-class="{{adminMessage.type}}") 
+					.alert.alert-info.alert-dismissable(ng-show="adminMessage", ng-class="{{adminMessage.type}}")
 						button.close(data-dismiss="alert") &times;
 						span {{adminMessage.content}}
-				.modal-body
 					.row
 						.col-md-6
 							.input-group
 								input.form-control(ng-model="user.username", placeholder="Find a user")
 								.dropdown.input-group-btn
-									a.btn.btn-default.dropdown-toggle(data-toggle="dropdown", href="#Change") Modify 
-										span.caret 
+									a.btn.btn-default.dropdown-toggle(data-toggle="dropdown", href="#Change") Modify
+										span.caret
 									ul.dropdown-menu.pull-right
 										li
 											a(ng-click="adminify()", href="#make-admin")
@@ -77,34 +70,35 @@
 										li
 											a(ng-click="demote()", href="#demote")
 												span.glyphicon.glyphicon-thumbs-down &nbsp;
-												span Demote 
+												span Demote
 										li
 											a(ng-click="boot()", href="#boot")
 												span.glyphicon.glyphicon-fire &nbsp;
 												span Boot
 
 div(ng-hide="me.auth")
-	div.col-md-6
-		h3 Log in
-		form(role="form")
-			div.form-group
-				input.form-control(ng-model="me.username", placeholder="Username")
-			div.form-group
-				input.form-control(ng-model="me.password", type="password", placeholder="Password")
-			button.btn.btn-default(ng-click="login()") Log in 
-				span.glyphicon.glyphicon-log-in 
+	.modal#user-login
+		div.column
+			h3 Log in
+			form(role="form")
+				div.form-group
+					input.form-control(ng-model="me.username", placeholder="Username")
+				div.form-group
+					input.form-control(ng-model="me.password", type="password", placeholder="Password")
+				button.btn.btn-default(ng-click="login()") Log in
+					span.glyphicon.glyphicon-log-in
 
-	div.col-md-6
-		h3 Create an Account
-		form(role="form")
-			div.form-group
-				label.sr-only(for="new-username") Create a username
-				input#new-username.form-control(ng-model="newUser.username", placeholder="Username")
-			div.form-group
-				label.sr-only(for="new-password1") Create a password
-				input#new-password1.form-control(ng-model="newUser.password1", type="password", placeholder="Create a password")
-			div.form-group
-				label.sr-only(for="new-password2") Enter your password again
-				input#new-password2.form-control(ng-model="newUser.password2", type="password", placeholder="Enter your password again")
-			button.btn.btn-default(ng-click="createUser()") Create an Account 
-				span.glyphicon.glyphicon-plus-sign
+		div.column
+			h3 Create an Account
+			form(role="form")
+				div.form-group
+					label.sr-only(for="new-username") Create a username
+					input#new-username.form-control(ng-model="newUser.username", placeholder="Username")
+				div.form-group
+					label.sr-only(for="new-password1") Create a password
+					input#new-password1.form-control(ng-model="newUser.password1", type="password", placeholder="Create a password")
+				div.form-group
+					label.sr-only(for="new-password2") Enter your password again
+					input#new-password2.form-control(ng-model="newUser.password2", type="password", placeholder="Enter your password again")
+				button.btn.btn-default(ng-click="createUser()") Create an Account
+					span.glyphicon.glyphicon-plus-sign

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -22,6 +22,8 @@ html.no-js(ng-app="cwfmApp")
 		block scripts
 	body
 		div.wrapper.main-wrapper.fixed-wrapper
+			block header
+
 			block right-col
 
 			block main-col

--- a/views/room.jade
+++ b/views/room.jade
@@ -21,14 +21,15 @@ block scripts
 	script(src="/public/js/cwfm.room.app.js")
 	script(src="/public/js/cwfm.room.ui.js")
 
+block header
+	header#cwfmUserCtrl(ng-controller="cwfmUserCtrl")
+		include includes/user
+
 block right-col
 	section.col.right-col.queue#cwfmPlaylistCtrl(ng-controller="cwfmPlaylistCtrl", data-step="6", data-intro="Here's where you manage your own playlists", data-position="left")
 		include includes/room/queue.jade
 
 block main-col
-	#cwfmUserCtrl(ng-controller="cwfmUserCtrl")
-		include includes/user
-
 	section.col.col-right.main-container
 		.col.stage
 			#cwfmRoomCtrl(ng-controller="cwfmRoomCtrl")


### PR DESCRIPTION
This branch is an attempt to start improving the display of the initial login screen and the account management modal. _Start_ being the keyword. I think that it'll be easier to iterate on once there is something in place, so although this isn't perfect it's a good step in the right direction I think.

First time you visit the app:
![image](https://cloud.githubusercontent.com/assets/17613/4367846/2d7e3f02-42e0-11e4-8533-494a8cf7012d.png)

After login when visiting room:
![image](https://cloud.githubusercontent.com/assets/17613/4367862/8178640c-42e0-11e4-8c27-3a0b1734ac06.png)

DropDown expanded:
![image](https://cloud.githubusercontent.com/assets/17613/4367865/90593974-42e0-11e4-874b-59627cd338d4.png)

Edit profile modal open:
![image](https://cloud.githubusercontent.com/assets/17613/4367868/a981d686-42e0-11e4-9d1f-1741a779ff9b.png)
